### PR TITLE
Improve right panel responsiveness

### DIFF
--- a/cust-dashboard/src/App.jsx
+++ b/cust-dashboard/src/App.jsx
@@ -222,10 +222,11 @@ function App() {
 
           {/* Right Card */}
           <div className="card custom-card shadow-sm p-4 d-flex flex-column border border-dark right-card">
-            <div className="scroll-area flex-grow-1">
-              <h6 className="fw-bold mb-3 text-center archivo-black-regular" >🔍 Sneak Peek: Dataset Sample</h6>
-              <div className="table-responsive">
-                <table className="table table-sm table-bordered text-center mb-0">
+            <div className="right-content scroll-area flex-grow-1">
+              <section className="dataset-section mb-4">
+                <h6 className="fw-bold mb-3 text-center archivo-black-regular" >🔍 Sneak Peek: Dataset Sample</h6>
+                <div className="table-responsive">
+                  <table className="table table-sm table-bordered text-center mb-0">
                       <thead className="table-light">
                         <tr>
                           <th>Age</th><th>Gender</th><th>Income</th><th>Purchases</th><th>Category</th>
@@ -239,13 +240,14 @@ function App() {
                         <tr><td>24</td><td>1</td><td>137799</td><td>19</td><td>3</td><td>46.2</td><td>0</td><td>4</td><td>1</td></tr>
                         <tr><td>31</td><td>1</td><td>99301</td><td>19</td><td>1</td><td>19.8</td><td>0</td><td>0</td><td>1</td></tr>
                       </tbody>
-                    </table>
-                  </div>
+                  </table>
+                </div>
+              </section>
 
 
 
 
-              <div className="mt-5 feature-imp-container">
+              <section className="mt-5 feature-imp-container">
                 <h6 className="fw-bold text-center mb-3 archivo-black-regular">📈 Feature Importance</h6>
                 <p className='archivo-black-regular'>
                   Feature importance is calculated by analyzing the coefficients of the independent variables. These coefficients are derived by minimizing binary cross-entropy loss using the gradient descent algorithm.
@@ -267,7 +269,7 @@ function App() {
                       </ResponsiveContainer>
                     </div>
                   </div>
-              </div>
+              </section>
             </div>
           </div>
         </div>

--- a/cust-dashboard/src/index.css
+++ b/cust-dashboard/src/index.css
@@ -90,7 +90,21 @@ html, body, #root {
 .feature-chart-inner {
   width: 100%;
   height: 250px;
-  min-width: 0;
+  min-width: 300px;
+}
+
+.right-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.dataset-section {
+  overflow-x: auto;
+}
+
+.dataset-section table {
+  min-width: 700px;
 }
 
 .feature-imp-container {
@@ -178,6 +192,14 @@ html, body, #root {
     box-sizing: border-box;
   }
 
+  .dataset-section table {
+    min-width: 600px;
+  }
+
+  .feature-chart-inner {
+    min-width: 250px;
+  }
+
   .left-card,
   .right-card {
     min-width: 100%;
@@ -230,6 +252,14 @@ html, body, #root {
   .feature-imp-container p {
     font-size: 0.9rem;
   }
+
+  .dataset-section table {
+    min-width: 600px;
+  }
+
+  .feature-chart-inner {
+    min-width: 250px;
+  }
 }
 
 @media (max-width: 481px) {
@@ -257,6 +287,15 @@ html, body, #root {
     max-width: 100%;
     height: auto;
     align-self: flex-start;
+  }
+
+  .dataset-section table {
+    min-width: 500px;
+  }
+
+  .feature-chart-inner {
+    min-width: 220px;
+    height: 200px;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure dataset sample and feature importance chart resize
- wrap right card content in new sections
- tweak responsive CSS for dataset table and bar chart

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dbd7ab56c832c87ef6f0078371d7e