### PR TITLE
Fix base path for Vercel

### DIFF
--- a/cust-dashboard/vite.config.js
+++ b/cust-dashboard/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/PurchasePulseAI/',
+  // On Vercel the app is served from the domain root.
+  // Fallback to the repo subpath for GitHub Pages deployments.
+  base: process.env.VERCEL ? '/' : '/PurchasePulseAI/',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- adjust Vite `base` config so assets load correctly on Vercel

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505be15160832c800fac44ae1d734e