### PR TITLE
Fix feature importance label size

### DIFF
--- a/cust-dashboard/src/App.jsx
+++ b/cust-dashboard/src/App.jsx
@@ -272,7 +272,12 @@ function App() {
                     >
                       <CartesianGrid strokeDasharray="3 3" />
                       <XAxis type="number" />
-                      <YAxis type="category" dataKey="name" />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
+                        tick={{ fontSize: 12 }}
+                        width={120}
+                      />
                       <Tooltip />
                       <Bar dataKey="value" fill="#8884d8" />
                     </BarChart>


### PR DESCRIPTION
## Summary
- make bar chart labels smaller with more width so text doesn't cut off

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508d3105bc832cb2aa85ed22f56f40