### PR TITLE
Add Vercel backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@
 
 
 
+## 🚀 Deploying on Vercel
+
+The project now includes serverless functions under the `api/` directory so the
+Flask backend can run on Vercel alongside the React frontend. When Vercel
+builds the app it sets the `VERCEL` environment variable, which the frontend
+uses to call these local API routes instead of the Render instance.
+

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,54 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+import joblib
+import numpy as np
+import os
+import pandas as pd
+from sklearn.metrics import confusion_matrix
+
+app = Flask(__name__)
+CORS(app)
+
+# Load model and dataset relative to repository root
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODEL_PATH = os.path.join(BASE_DIR, 'prediction', 'logistic_model.pkl')
+DATA_PATH = os.path.join(BASE_DIR, 'prediction', 'dataset1.csv')
+
+model = joblib.load(MODEL_PATH)
+
+df = pd.read_csv(DATA_PATH)
+X_full = df[['Age', 'NumberOfPurchases', 'LoyaltyProgram', 'DiscountsAvailed']].copy()
+X_full['LPxD'] = X_full['LoyaltyProgram'] * X_full['DiscountsAvailed']
+TEST_X = X_full.iloc[:1500].to_numpy()
+TEST_Y = df['PurchaseStatus'].iloc[:1500].to_numpy()
+
+@app.post('/predict')
+def predict():
+    data = request.get_json()
+    features = data['features']
+    columns = ['Age', 'NumberOfPurchases', 'LoyaltyProgram', 'DiscountsAvailed', 'LoyaltyProgram_Discounts']
+    X_input = pd.DataFrame([features], columns=columns)
+    prediction = model.predict(X_input)[0]
+    return jsonify({'prediction': int(prediction)})
+
+@app.get('/performance')
+def performance():
+    named = pd.DataFrame(TEST_X, columns=[
+        'Age', 'NumberOfPurchases', 'LoyaltyProgram', 'DiscountsAvailed', 'LoyaltyProgram_Discounts'
+    ])
+    preds = model.predict(named)
+    tn, fp, fn, tp = confusion_matrix(TEST_Y, preds).ravel()
+    return jsonify({'TP': int(tp), 'TN': int(tn), 'FP': int(fp), 'FN': int(fn)})
+
+@app.get('/importance')
+def importance():
+    feature_names = ['age', 'purchases', 'loyalty', 'discounts', 'discounts x loyalty']
+    coefficients = model.coef_[0]
+    importance = np.abs(coefficients)
+    feature_importance = [
+        {'name': name, 'value': float(val)}
+        for name, val in zip(feature_names, importance)
+    ]
+    feature_importance.sort(key=lambda x: x['value'], reverse=True)
+    return jsonify(feature_importance)
+

--- a/cust-dashboard/src/App.jsx
+++ b/cust-dashboard/src/App.jsx
@@ -72,6 +72,10 @@ function App() {
   ];
   const [loyaltyError, setLoyaltyError] = useState('');
 
+  const API_BASE = process.env.VERCEL
+    ? '/api/app'
+    : 'https://purchasepulseai.onrender.com';
+
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
@@ -95,7 +99,7 @@ function App() {
     const features = [age, purchases, loyalty, discounts, lp_discounts];
 
     try {
-      const res = await fetch('https://purchasepulseai.onrender.com/predict', {
+      const res = await fetch(`${API_BASE}/predict`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ features })
@@ -111,7 +115,7 @@ function App() {
   };
 
   useEffect(() => {
-    fetch('https://purchasepulseai.onrender.com/performance')
+    fetch(`${API_BASE}/performance`)
       .then(res => res.json())
       .then(data => {
         const chartData = [
@@ -126,7 +130,7 @@ function App() {
         console.error('Failed to fetch model performance:', err);
       });
 
-    fetch('https://purchasepulseai.onrender.com/importance')
+    fetch(`${API_BASE}/importance`)
       .then(res => {
         if (!res.ok) throw new Error('Network response was not ok');
         return res.json();

--- a/cust-dashboard/vite.config.js
+++ b/cust-dashboard/vite.config.js
@@ -6,4 +6,8 @@ export default defineConfig({
   // Fallback to the repo subpath for GitHub Pages deployments.
   base: process.env.VERCEL ? '/' : '/PurchasePulseAI/',
   plugins: [react()],
+  define: {
+    'process.env': process.env,
+  },
 });
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flask
+flask-cors
+joblib
+numpy
+pandas
+scikit-learn


### PR DESCRIPTION
## Summary
- create serverless Flask API for Vercel
- allow frontend to use the Vercel API when deployed
- expose environment variables in Vite config
- document Vercel deployment
- add Python requirements

## Testing
- `npm --prefix cust-dashboard run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850fd9484cc832cb3c8f0a0854757e9