### PR TITLE
Add pytest setup and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,16 @@ Flask backend can run on Vercel alongside the React frontend. When Vercel
 builds the app it sets the `VERCEL` environment variable, which the frontend
 uses to call these local API routes instead of the Render instance.
 
+## 🧪 Running Tests
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ joblib
 numpy
 pandas
 scikit-learn
+pytest

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from api.app import app
+
+
+def test_predict_route():
+    client = app.test_client()
+    payload = {"features": [30, 2, 1, 1, 1]}
+    response = client.post('/predict', json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert 'prediction' in data


### PR DESCRIPTION
## Summary
- add Flask package init for importing
- add simple `/predict` test
- include pytest in requirements
- document test usage in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68510091a088832c99ed9de8872dbbf6