### PR TITLE
Fix Vercel build by bundling model assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,13 @@
   "version": 2,
   "builds": [
     { "src": "cust-dashboard/package.json", "use": "@vercel/static-build", "config": { "distDir": "cust-dashboard/dist" } },
-    { "src": "api/app.py", "use": "@vercel/python" }
+    {
+      "src": "api/app.py",
+      "use": "@vercel/python",
+      "config": {
+        "includeFiles": "prediction/**"
+      }
+    }
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "api/app.py" },


### PR DESCRIPTION
## Summary
- ensure prediction assets are bundled with the Vercel Python function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6851044d50cc832c91cb71929d0f491a