### PR TITLE
Fix Vercel build output path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "builds": [
-    { "src": "cust-dashboard/package.json", "use": "@vercel/static-build", "config": { "distDir": "cust-dashboard/dist" } },
+    { "src": "cust-dashboard/package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } },
     {
       "src": "api/app.py",
       "use": "@vercel/python",


### PR DESCRIPTION
## Summary
- fix the `distDir` path so Vercel can find the build output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685105d8e1bc832cb3e9d5270a6034b0