### PR TITLE
Revert serverless backend, keep Render API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,18 @@ PurchasePulseAI/
 ├── cust-dashboard/   # React frontend
 │   └── src/
 │       └── App.jsx   # main app component
-├── api/              # Flask serverless API
+├── api/              # Flask API
 │   └── app.py        # prediction endpoints
 └── prediction/       # model and dataset
     ├── logistic_model.pkl
     └── dataset1.csv
 ```
 
-## 🚀 Deploying on Vercel
+## 🚀 Deploying
 
-The project now includes serverless functions under the `api/` directory so the
-Flask backend can run on Vercel alongside the React frontend. When Vercel
-builds the app it sets the `VERCEL` environment variable, which the frontend
-uses to call these local API routes instead of the Render instance.
+The React dashboard is deployed on Vercel. The Flask backend runs separately on
+Render at `https://purchasepulseai.onrender.com`, and the frontend sends its API
+requests to that URL.
 
 ## 🧪 Running Tests
 

--- a/cust-dashboard/src/App.jsx
+++ b/cust-dashboard/src/App.jsx
@@ -72,9 +72,7 @@ function App() {
   ];
   const [loyaltyError, setLoyaltyError] = useState('');
 
-  const API_BASE = process.env.VERCEL
-    ? '/api/app'
-    : 'https://purchasepulseai.onrender.com';
+  const API_BASE = 'https://purchasepulseai.onrender.com';
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });

--- a/cust-dashboard/vite.config.js
+++ b/cust-dashboard/vite.config.js
@@ -6,8 +6,5 @@ export default defineConfig({
   // Fallback to the repo subpath for GitHub Pages deployments.
   base: process.env.VERCEL ? '/' : '/PurchasePulseAI/',
   plugins: [react()],
-  define: {
-    'process.env': process.env,
-  },
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,9 @@
 {
   "version": 2,
   "builds": [
-    { "src": "cust-dashboard/package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } },
-    {
-      "src": "api/app.py",
-      "use": "@vercel/python",
-      "config": {
-        "includeFiles": "prediction/**"
-      }
-    }
+    { "src": "cust-dashboard/package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
   ],
   "routes": [
-    { "src": "/api/(.*)", "dest": "api/app.py" },
     { "src": "/(.*)", "dest": "cust-dashboard/dist/$1" }
   ]
 }


### PR DESCRIPTION
## Summary
- remove serverless backend build from `vercel.json`
- point React dashboard to Render API
- simplify Vite config
- update docs to reflect backend hosted on Render

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685109328160832c82b890e098be8f1a